### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "ruby"
+  run = "ruby mastermind.rb"
+  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the game Mastermind, played on the command line.
 
 To play it clone this repo and execute
 the file "mastermind.rb" or you can
-play it online on [repl.it](https://repl.it/@jodokusquack/mastermind).
+play it online on [![Run on Repl.it](https://repl.it/badge/github/jodokusquack/mastermind)](https://repl.it/github/jodokusquack/mastermind).
 
 The objective of the Codebreaker is to guess the Codemaker's Colorcode in 10 turns or less.
 After each guess the Codemaker gives some hints about the guess that was made:


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).